### PR TITLE
fix: fix deprecated import bug in django4.0

### DIFF
--- a/nextServer/urls.py
+++ b/nextServer/urls.py
@@ -16,13 +16,12 @@ Including another URLconf
 Router system: url --- view
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, re_path
 
 from . import views
-from django.conf.urls import url
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    url(r'^$', views.hello),
+    re_path(r'^$', views.hello),
     path('hello/', views.hello_world)
 ]


### PR DESCRIPTION
django.conf.urls.url() was deprecated in Django 3.0, and is removed in
Django 4.0+.
replace url() with re_path().